### PR TITLE
Add readme for the top level and overall github actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
-# cicd
+# Gable CI/CD integrations
 
-Native CI/CD integrations that wrap Gable's [Python CLI](https://pypi.org/project/gable/) for interacting with Gable data contracts.
+[Gable](https://gable.ai) publishes CI/CD integrations to make it easy to integrate the Gable platform in your CI/CD workflows.
+
+* [GitHub Actions](github-actions/)
+* [GitLab Reusable Template](gitlab/)

--- a/github-actions/README.md
+++ b/github-actions/README.md
@@ -1,0 +1,17 @@
+# Github Actions
+
+Gable publishes several Github Actions to make it easy to integrate the Gable platform in your Github Actions workflows.
+These Actions are thin interfaces to expose [Gable's Command Line Interface](https://pypi.org/project/gable/) and make sure
+the right exit codes are returned based on your configuration in Gable.
+
+* [Check Data Assets](check-data-assets/): Check if data assets are in compliance with existing data contracts.
+* [Publish Contracts](publish-contracts/): Publish data contracts to the Gable platform.
+* [Register data assets](register-data-assets/): Register and update data assets with the Gable platform.
+* [Validate Contracts](validate-contracts/): Validate data contracts are well formed.
+
+## Usage
+
+There are a few inputs that every Action requires.
+
+* `gable-api-endpoint`: The URL of the Gable API endpoint. You can find instructions on finding this at `/docs/api_keys` in your company's Gable application.
+* `gable-api-key`: The API key to use to authenticate with the Gable API. You can find instructions on finding this at `/docs/api_keys` in your company's Gable application.

--- a/github-actions/check-data-assets/action.yml
+++ b/github-actions/check-data-assets/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'Gable API Key'
     required: true
   gable-version:
-    description: 'Gable Version'
+    description: 'Gable CLI Version. See https://pypi.org/project/gable/#history for a list of available versions.'
     required: false
     default: 'latest'
   allow-gable-pre-release:

--- a/github-actions/publish-contracts/action.yml
+++ b/github-actions/publish-contracts/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: 'Gable API Key'
     required: true
   gable-version:
-    description: 'Gable Version'
+    description: 'Gable CLI Version. See https://pypi.org/project/gable/#history for a list of available versions.'
     required: false
     default: 'latest'
   allow-gable-pre-release:

--- a/github-actions/register-data-assets/action.yml
+++ b/github-actions/register-data-assets/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'Gable API Key'
     required: true
   gable-version:
-    description: 'Gable Version'
+    description: 'Gable CLI Version. See https://pypi.org/project/gable/#history for a list of available versions.'
     required: false
     default: 'latest'
   allow-gable-pre-release:

--- a/github-actions/validate-contracts/action.yml
+++ b/github-actions/validate-contracts/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'Gable API Key'
     required: true
   gable-version:
-    description: 'Gable Version'
+    description: 'Gable CLI Version. See https://pypi.org/project/gable/#history for a list of available versions.'
     required: false
     default: 'latest'
   allow-gable-pre-release:


### PR DESCRIPTION
Currently, it is a bit hard to get started with the github actions published here without guidance from documentation elsewhere.

* This adds a top level readme so if you just arrive at this repo, you know where to go next.
* It also adds a top level readme for the github actions which provides context needed for using any of them.
* I also clarify the meaning of `gable-version` in the action input descriptions.

I plan to follow up on these with more detail on each action and give more context around the gitlab reusable template.