### PR TITLE
add readmes for each github action including inputs and CLI help text

### DIFF
--- a/github-actions/check-data-assets/README.md
+++ b/github-actions/check-data-assets/README.md
@@ -1,10 +1,23 @@
-# check-data-assets
+# Gable: Check Data Assets
 
 Checks the data assets specified in the command against their contracts in Gable.
 
 This action is a thin wrapper around the `gable` [Python CLI](https://pypi.org/project/gable/)
 
-```
+## Inputs
+
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| gable-api-endpoint | Gable API Endpoint in the format https://api.<organization>.gabledata.com | `true` |  |
+| gable-api-key | Gable API Key | `true` |  |
+| gable-version | Gable Version | `false` | latest |
+| allow-gable-pre-release | Whether or not to install pre-release versions of Gable | `false` | false |
+| data-asset-options | Options passed in to the 'gable data-asset check' command  | `true` |  |
+| github-token | Github token used to comment on PR | `false` | ${{ github.token }} |
+
+## CLI Help (for version 0.6.0)
+
+```bash
 Usage: gable data-asset check [OPTIONS]
 
   Checks data asset(s) against a contract
@@ -19,7 +32,11 @@ Options:
                                   
                                   For protobuf/avro/json_schema the check will
                                   be performed for all file(s)  [required]
-  Database Options:               Options for checking contract complaince for
+  -o, --output [text|json|markdown]
+                                  Format of the output. Options are: text
+                                  (default), json, or markdown which is
+                                  intended to be used as a PR comment
+  Database Options:               Options for checking contract compliance for
                                   tables in a relational database. The check
                                   will be performed for any tables that have a
                                   contract associated with them.
@@ -36,20 +53,17 @@ Options:
                                   needing to connect to the production
                                   database, the host is still needed to
                                   generate the unique resource  name for the
-                                  real data asset so we can look up any
-                                  associated contracts.
+                                  real database tables (data assets).
     -p, --port INTEGER            The port of the production database. Despite
                                   not needing to connect to the production
                                   database, the port is  still needed to
                                   generate the unique resource name for the
-                                  real data asset so we can look up any
-                                  associated contracts.
+                                  real database tables (data assets).
     --db TEXT                     The name of the production database. Despite
                                   not needing to connect to the production
                                   database, the database  name is still needed
                                   to generate the unique resource name for the
-                                  real data asset so we can look up any
-                                  associated  contracts.
+                                  real database tables (data assets).
                                   
                                   Database naming convention frequently
                                   includes the environment
@@ -67,13 +81,12 @@ Options:
                                   is 'test_service_one',  you would set --db
                                   to 'prod_service_one' and --proxy-db to
                                   'test_service_one'.
-    -s, --schema TEXT             The schema of the production database where
-                                  the table(s) you want to register are
-                                  located. Despite not  needing to connect to
-                                  the production database, the schema is still
-                                  needed to generate the unique resource name
-                                  for the real data asset so we can look up
-                                  any associated contracts.'
+    -s, --schema TEXT             The schema of the production database
+                                  containing the table(s) to check. Despite
+                                  not needing to connect to  the production
+                                  database, the schema is still needed to
+                                  generate the unique resource name for the
+                                  real database tables (data assets).
                                   
                                   Database naming convention frequently
                                   includes the environment
@@ -90,9 +103,10 @@ Options:
                                   'production', but your test database is
                                   'test',  you would set --schema to
                                   'production' and --proxy-schema to 'test'.
-    -t, --table TEXT              The table to check for contract violations.
-                                  If no table is specified, all tables within
-                                  the provided  schema will be checked.
+    -t, --table, --tables TEXT    A comma delimited list of the table(s) to
+                                  check. If no table(s) are specified, all
+                                  tables within the provided schema will be
+                                  checked.
                                   
                                   Table names in the proxy database instance
                                   must match the table names in the production
@@ -101,53 +115,64 @@ Options:
     -ph, --proxy-host TEXT        The host string of the database instance
                                   that serves as the proxy for the production
                                   database. This is the  database that Gable
-                                  will connect to when checking tables for
-                                  contract violations in the CI/CD workflow.
+                                  will connect to when checking tables in the
+                                  CI/CD workflow.
     -pp, --proxy-port INTEGER     The port of the database instance that
                                   serves as the proxy for the production
                                   database. This is the  database that Gable
-                                  will connect to when checking tables for
-                                  contract violations in the CI/CD workflow.
+                                  will connect to when checking tables in the
+                                  CI/CD workflow.
     -pdb, --proxy-db TEXT         Only needed if the name of the database in
                                   the proxy instance is different than the
-                                  name of the production database.
+                                  name of the production database. If not
+                                  specified, the value of --db will be used to
+                                  generate the unique resource name for  the
+                                  data asset.
                                   
-                                  If not specified, the value of --db will be
-                                  used to generate the unique resource name
-                                  for the data asset. For example, if your
-                                  production database is 'prod_service_one',
-                                  but your test database is
-                                  'test_service_one', you would set --db to
-                                  'prod_service_one' and --proxy-db to
+                                  For example, if your production database is
+                                  'prod_service_one', but your test database
+                                  is 'test_service_one',  you would set --db
+                                  to 'prod_service_one' and --proxy-db to
                                   'test_service_one'.
     -ps, --proxy-schema TEXT      Only needed if the name of the schema in the
                                   proxy instance is different than the name of
-                                  the schema in the production database.
+                                  the schema in the production database. If
+                                  not specified, the value of --schema will be
+                                  used to generate the unique resource name
+                                  for  the data asset.
                                   
-                                  If not specified, the value of --schema will
-                                  be used to generate the unique resource name
-                                  for the data asset. For example, if your
-                                  production schema is 'production', but your
-                                  test database is 'test', you would set
-                                  --schema to 'production' and --proxy-schema
-                                  to 'test'.
+                                  For example, if your production schema is
+                                  'production', but your test database is
+                                  'test', you would set --schema to
+                                  'production' and --proxy-schema to 'test'.
     -pu, --proxy-user TEXT        The user that will be used to connect to the
                                   proxy database instance that serves as the
                                   proxy for the production  database. This is
                                   the database that Gable will connect to when
-                                  checking tables for contract violations in
-                                  the CI/CD workflow.
+                                  checking tables in the CI/CD workflow.
     -ppw, --proxy-password TEXT   If specified, the password that will be used
                                   to connect to the proxy database instance
                                   that serves as the proxy for  the production
                                   database. This is the database that Gable
-                                  will connect to when checking tables for
-                                  contract violations in  the CI/CD workflow.
-  Protobuf & Avro options: [all_or_none]
-                                  Options for checking Protobuf message(s),
+                                  will connect to when checking tables in the
+                                  CI/CD workflow.
+  Protobuf & Avro options:        Options for checking Protobuf message(s),
                                   Avro record(s), or JSON schema object(s)for
                                   contract violations.
-    --files TUPLE
+    --files TUPLE                 Space delimited path(s) to the contracts to
+                                  check, with support for glob patterns.
+  Global Options: 
+    --endpoint TEXT               Customer API endpoint for Gable, in the
+                                  format https://api.company.gable.ai/. Can
+                                  also be set with the GABLE_API_ENDPOINT
+                                  environment variable.  [required]
+    --api-key TEXT                API Key for Gable. Can also be set with the
+                                  GABLE_API_KEY environment variable.
+                                  [required]
+    --debug                       Enable debug logging
+    --trace                       Enable trace logging. This is the most
+                                  verbose logging level and should only be
+                                  used for debugging.
   --help                          Show this message and exit.
 
   Example:

--- a/github-actions/check-data-assets/README.md
+++ b/github-actions/check-data-assets/README.md
@@ -8,7 +8,7 @@ This action is a thin wrapper around the `gable` [Python CLI](https://pypi.org/p
 
 | parameter | description | required | default |
 | --- | --- | --- | --- |
-| gable-api-endpoint | Gable API Endpoint in the format https://api.<organization>.gabledata.com | `true` |  |
+| gable-api-endpoint | Gable API Endpoint in the format `https://api.<organization>.gabledata.com` | `true` |  |
 | gable-api-key | Gable API Key | `true` |  |
 | gable-version | Gable Version | `false` | latest |
 | allow-gable-pre-release | Whether or not to install pre-release versions of Gable | `false` | false |

--- a/github-actions/check-data-assets/action.yml
+++ b/github-actions/check-data-assets/action.yml
@@ -1,6 +1,6 @@
 name: check-data-assets
 author: gabledata
-description: Checks data assets defined in a product repository against their data contracts defined in Gable
+description: Checks the data assets specified in the command against their contracts in Gable.
 inputs:
   gable-api-endpoint:
     description: 'Gable API Endpoint in the format https://api.<organization>.gabledata.com'

--- a/github-actions/publish-contracts/README.md
+++ b/github-actions/publish-contracts/README.md
@@ -1,16 +1,36 @@
-# publish-contracts
+# Gable: Publish Contracts
 
-Publishes contracts to Gable.
+Publishes new or updated contracts to Gable. Publishing a contract is idempotent - if no update has been made to the contract the
+publish will be a no-op, so it's safe to publish all contracts on every run.
 
-This action is a thin wrapper around the `gable` [Python CLI](https://pypi.org/project/gable/)
+## Inputs
 
-```
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| gable-api-endpoint | Gable API Endpoint in the format https://api.<organization>.gabledata.com | `true` |  |
+| gable-api-key | Gable API Key | `true` |  |
+| gable-version | Gable Version | `false` | latest |
+| allow-gable-pre-release | Whether or not to install pre-release versions of Gable | `false` | false |
+| contract-paths | Space delimited path(s) to the contracts to publish, with support for glob patterns. Example:    "service1/**/*.yml contracts/service2/example_contract.yml" This input may also be specified as a multiline string, with each line representing a path to contract(s) to publish. Example:   contract-paths: |     service1/**/*.yml     service2/example_contract.yml  | `true` |  |
+
+## CLI Help (for version 0.6.0)
+
+```bash
 Usage: gable contract publish [OPTIONS] [CONTRACT_FILES]...
 
   Publishes data contracts to Gable
 
 Options:
-  --help  Show this message and exit.
+  Global Options: 
+    --endpoint TEXT  Customer API endpoint for Gable, in the format
+                     https://api.company.gable.ai/. Can also be set with the
+                     GABLE_API_ENDPOINT environment variable.  [required]
+    --api-key TEXT   API Key for Gable. Can also be set with the GABLE_API_KEY
+                     environment variable.  [required]
+    --debug          Enable debug logging
+    --trace          Enable trace logging. This is the most verbose logging
+                     level and should only be used for debugging.
+  --help             Show this message and exit.
 
   Examples:
 

--- a/github-actions/publish-contracts/README.md
+++ b/github-actions/publish-contracts/README.md
@@ -11,30 +11,4 @@ publish will be a no-op, so it's safe to publish all contracts on every run.
 | gable-api-key | Gable API Key | `true` |  |
 | gable-version | Gable Version | `false` | latest |
 | allow-gable-pre-release | Whether or not to install pre-release versions of Gable | `false` | false |
-| contract-paths | Space delimited path(s) to the contracts to publish, with support for glob patterns. Example:    "service1/**/*.yml contracts/service2/example_contract.yml" This input may also be specified as a multiline string, with each line representing a path to contract(s) to publish. Example:   contract-paths: |     service1/**/*.yml     service2/example_contract.yml  | `true` |  |
-
-## CLI Help (for version 0.6.0)
-
-```bash
-Usage: gable contract publish [OPTIONS] [CONTRACT_FILES]...
-
-  Publishes data contracts to Gable
-
-Options:
-  Global Options: 
-    --endpoint TEXT  Customer API endpoint for Gable, in the format
-                     https://api.company.gable.ai/. Can also be set with the
-                     GABLE_API_ENDPOINT environment variable.  [required]
-    --api-key TEXT   API Key for Gable. Can also be set with the GABLE_API_KEY
-                     environment variable.  [required]
-    --debug          Enable debug logging
-    --trace          Enable trace logging. This is the most verbose logging
-                     level and should only be used for debugging.
-  --help             Show this message and exit.
-
-  Examples:
-
-  gable contract publish contract1.yaml
-
-  gable contract publish **/*.yaml
-```
+| contract-paths | Space delimited path(s) to the contracts to publish, with support for glob patterns. Example:    `"service1/**/*.yml contracts/service2/example_contract.yml"`. This input may also be specified as a multiline string, with each line representing a path to contract(s) to publish. | `true` |  |

--- a/github-actions/publish-contracts/README.md
+++ b/github-actions/publish-contracts/README.md
@@ -7,7 +7,7 @@ publish will be a no-op, so it's safe to publish all contracts on every run.
 
 | parameter | description | required | default |
 | --- | --- | --- | --- |
-| gable-api-endpoint | Gable API Endpoint in the format https://api.<organization>.gabledata.com | `true` |  |
+| gable-api-endpoint | Gable API Endpoint in the format `https://api.<organization>.gabledata.com` | `true` |  |
 | gable-api-key | Gable API Key | `true` |  |
 | gable-version | Gable Version | `false` | latest |
 | allow-gable-pre-release | Whether or not to install pre-release versions of Gable | `false` | false |

--- a/github-actions/register-data-assets/README.md
+++ b/github-actions/register-data-assets/README.md
@@ -6,7 +6,7 @@ Checks data assets defined in a product repository against any contracts defined
 
 | parameter | description | required | default |
 | --- | --- | --- | --- |
-| gable-api-endpoint | Gable API Endpoint in the format https://api.<organization>.gabledata.com | `true` |  |
+| gable-api-endpoint | Gable API Endpoint in the format `https://api.<organization>.gabledata.com` | `true` |  |
 | gable-api-key | Gable API Key | `true` |  |
 | gable-version | Gable Version | `false` | latest |
 | allow-gable-pre-release | Whether or not to install pre-release versions of Gable | `false` | false |

--- a/github-actions/validate-contracts/README.md
+++ b/github-actions/validate-contracts/README.md
@@ -6,7 +6,7 @@ Syntax validation of Gable data contracts.
 
 | parameter | description | required | default |
 | --- | --- | --- | --- |
-| gable-api-endpoint | Gable API Endpoint in the format https://api.<organization>.gabledata.com | `true` |  |
+| gable-api-endpoint | Gable API Endpoint in the format `https://api.<organization>.gabledata.com` | `true` |  |
 | gable-api-key | Gable API Key | `true` |  |
 | gable-version | Gable Version | `false` | latest |
 | allow-gable-pre-release | Whether or not to install pre-release versions of Gable | `false` | false |

--- a/github-actions/validate-contracts/README.md
+++ b/github-actions/validate-contracts/README.md
@@ -1,20 +1,38 @@
-# validate-contracts
+# Gable: Validate Contracts
 
 Syntax validation of Gable data contracts.
 
-This action is a thin wrapper around the `gable` [Python CLI](https://pypi.org/project/gable/)
+## Inputs
 
-```
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| gable-api-endpoint | Gable API Endpoint in the format https://api.<organization>.gabledata.com | `true` |  |
+| gable-api-key | Gable API Key | `true` |  |
+| gable-version | Gable Version | `false` | latest |
+| allow-gable-pre-release | Whether or not to install pre-release versions of Gable | `false` | false |
+| contract-paths | Space delimited path(s) to the contracts to validate, with support for glob patterns. Example:    "service1/**/*.yml contracts/service2/example_contract.yml" This input may also be specified as a multiline string, with each line representing a path to contract(s) to validate. Example:   contract-paths: |     service1/**/*.yml     service2/example_contract.yml  | `true` |  |
+
+## CLI Help (for version 0.6.0)
+
+```bash
 Usage: gable contract validate [OPTIONS] [CONTRACT_FILES]...
 
-  Validates the syntax of the data contract files
+  Validates the configuration of the data contract files
 
 Options:
-  --help  Show this message and exit.
+  Global Options: 
+    --endpoint TEXT  Customer API endpoint for Gable, in the format
+                     https://api.company.gable.ai/. Can also be set with the
+                     GABLE_API_ENDPOINT environment variable.  [required]
+    --api-key TEXT   API Key for Gable. Can also be set with the GABLE_API_KEY
+                     environment variable.  [required]
+    --debug          Enable debug logging
+    --trace          Enable trace logging. This is the most verbose logging
+                     level and should only be used for debugging.
+  --help             Show this message and exit.
 
   Examples:
 
-  gable contract validate contract1.yaml
-
-  gable contract validate **/*.yaml
+    gable contract validate contract1.yaml
+    gable contract validate **/*.yaml
 ```

--- a/github-actions/validate-contracts/README.md
+++ b/github-actions/validate-contracts/README.md
@@ -10,29 +10,4 @@ Syntax validation of Gable data contracts.
 | gable-api-key | Gable API Key | `true` |  |
 | gable-version | Gable Version | `false` | latest |
 | allow-gable-pre-release | Whether or not to install pre-release versions of Gable | `false` | false |
-| contract-paths | Space delimited path(s) to the contracts to validate, with support for glob patterns. Example:    "service1/**/*.yml contracts/service2/example_contract.yml" This input may also be specified as a multiline string, with each line representing a path to contract(s) to validate. Example:   contract-paths: |     service1/**/*.yml     service2/example_contract.yml  | `true` |  |
-
-## CLI Help (for version 0.6.0)
-
-```bash
-Usage: gable contract validate [OPTIONS] [CONTRACT_FILES]...
-
-  Validates the configuration of the data contract files
-
-Options:
-  Global Options: 
-    --endpoint TEXT  Customer API endpoint for Gable, in the format
-                     https://api.company.gable.ai/. Can also be set with the
-                     GABLE_API_ENDPOINT environment variable.  [required]
-    --api-key TEXT   API Key for Gable. Can also be set with the GABLE_API_KEY
-                     environment variable.  [required]
-    --debug          Enable debug logging
-    --trace          Enable trace logging. This is the most verbose logging
-                     level and should only be used for debugging.
-  --help             Show this message and exit.
-
-  Examples:
-
-    gable contract validate contract1.yaml
-    gable contract validate **/*.yaml
-```
+| contract-paths | White space delimited path(s) to the contracts to validate, with support for glob patterns. Example:    `"service1/**/*.yml contracts/service2/example_contract.yml"`. This input may also be specified as a multiline string, with each line representing a path to contract(s) to publish. | `true` |  |


### PR DESCRIPTION
I used https://github.com/npalm/action-docs to generate the `Inputs` table for each of the github actions.

I used the gable CLI on version `0.6.0` to update the help text for each of the actions.

We might consider automating either of these in the future.