### PR TITLE
upgrade actions/checkout and actions/setup-python to latest to use node20

### DIFF
--- a/github-actions/check-data-assets/action.yml
+++ b/github-actions/check-data-assets/action.yml
@@ -34,7 +34,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.10.11
     - name: Install Gable
@@ -52,7 +52,7 @@ runs:
         fi
         gable --version
     - name: Check out repository code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # Don't clean the repository before checking out the code, we don't want to remove any virtual environments or dependencies
         # that may have been installed

--- a/github-actions/publish-contracts/action.yml
+++ b/github-actions/publish-contracts/action.yml
@@ -31,7 +31,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         # TODO: maintain compatibility list for gable versions
         python-version: 3.10.11
@@ -49,7 +49,7 @@ runs:
           pip install -q gable==${{ inputs.gable-version }} $PRE_RELEASE_TAG
         fi
     - name: Check out repository code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # Don't clean the repository before checking out the code, we don't want to remove any virtual environments or dependencies
         # that may have been installed

--- a/github-actions/register-data-assets/action.yml
+++ b/github-actions/register-data-assets/action.yml
@@ -34,7 +34,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.10.11
     - name: Install Gable
@@ -51,7 +51,7 @@ runs:
           ${{ inputs.python-path }} -m  install -q gable[postgres,mysql]==${{ inputs.gable-version }} $PRE_RELEASE_TAG
         fi
     - name: Check out repository code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # Don't clean the repository before checking out the code, we don't want to remove any virtual environments or dependencies
         # that may have been installed

--- a/github-actions/validate-contracts/action.yml
+++ b/github-actions/validate-contracts/action.yml
@@ -29,7 +29,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         # TODO: maintain compatibility list for gable versions
         python-version: 3.10.11
@@ -47,7 +47,7 @@ runs:
           pip install -q gable==${{ inputs.gable-version }} $PRE_RELEASE_TAG
         fi
     - name: Check out repository code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # Don't clean the repository before checking out the code, we don't want to remove any virtual environments or dependencies
         # that may have been installed


### PR DESCRIPTION
Github Actions gives warnings when you use actions that use node 16 and tells you which actions are responsible for using that. 

<img width="1286" alt="Screenshot 2024-04-09 at 8 01 59 PM" src="https://github.com/gabledata/cicd/assets/3848371/0ed8fe65-78b7-4adb-b540-647fb4411108">

This updates our dependent actions to the latest version. I checked the described changes in these versions and it shouldn't otherwise impact behavior.

* `actions/checkout` [changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md#v400)
* `actions/setup-repo`[releases](https://github.com/actions/setup-python/releases)
