### PR TITLE
get pr number with cli on push

### DIFF
--- a/github-actions/check-data-assets/README.md
+++ b/github-actions/check-data-assets/README.md
@@ -15,6 +15,15 @@ This action is a thin wrapper around the `gable` [Python CLI](https://pypi.org/p
 | data-asset-options | Options passed in to the 'gable data-asset check' command  | `true` |  |
 | github-token | Github token used to comment on PR | `false` | ${{ github.token }} |
 
+## Permissions
+
+If you are running this action `on: push` instead of `on: pull_request` and want Gable to comment on the PR, you will need to configure your job with PR permissions. For example:
+
+```yaml
+permissions:
+  pull-requests: read # required for Gable to find the PR associated with the pushed commit
+```
+
 ## CLI Help (for version 0.6.0)
 
 ```bash

--- a/github-actions/check-data-assets/action.yml
+++ b/github-actions/check-data-assets/action.yml
@@ -59,7 +59,6 @@ runs:
         clean: 'false'
     - name: "Validate Contracts"
       env: 
-        PR_NUMBER: ${{ github.event.number }}
         GH_TOKEN: ${{ inputs.github-token }}
       shell: "bash"
       run: |
@@ -72,7 +71,13 @@ runs:
           DEBUG=""
         fi
         export PYTHON_PATH="${{ inputs.python-path }}"
-        # If this was run on pull_request, comment on the PR if necessary
+
+        # Populated if we're running on: pull_request
+        PR_NUMBER=${{ github.event.number }}
+        if [[ "$PR_NUMBER" == "" ]]; then
+          # We might be running on: push, in which case try the CLI to get the PR associated with the commit
+          PR_NUMBER=$(gh pr view --json number --jq '.number' || true)
+        fi
         if [[ "$PR_NUMBER" != "" ]]; then
           # Don't fail the comment step (yet) if we get a BLOCK result, but capture the exit code
           set +e

--- a/github-actions/check-data-assets/action.yml
+++ b/github-actions/check-data-assets/action.yml
@@ -75,8 +75,10 @@ runs:
         # Populated if we're running on: pull_request
         PR_NUMBER=${{ github.event.number }}
         if [[ "$PR_NUMBER" == "" ]]; then
+          echo "No PR number found from github.event.number, trying to get it with the CLI"
           # We might be running on: push, in which case try the CLI to get the PR associated with the commit
           PR_NUMBER=$(gh pr view --json number --jq '.number' || true)
+          echo "PR number found: $PR_NUMBER"
         fi
         if [[ "$PR_NUMBER" != "" ]]; then
           # Don't fail the comment step (yet) if we get a BLOCK result, but capture the exit code


### PR DESCRIPTION
## What + How
We have mostly been testing the `check` action when triggered via `on: pull_request`, however some customers will likely be running `check` `on: push`. On push there are different github context variables populated, and the PR number isn't accessible in the way we currently look for it.

This PR adds an additional step using the github CLI [gh pr view](https://cli.github.com/manual/gh_pr_view) to get the pr number associated with the branch.

## Validation

I did a test run using this commit's version `on: push` and saw the PR comment made. ✅ 