### PR TITLE
Install mssql package in github action

### DIFF
--- a/github-actions/check-data-assets/action.yml
+++ b/github-actions/check-data-assets/action.yml
@@ -51,9 +51,9 @@ runs:
           PRE_RELEASE_TAG=""
         fi
         if [[ "${{ inputs.gable-version }}" == "latest" ]]; then
-          ${{ inputs.python-path }} -m pip install -q gable[postgres,mysql] $PRE_RELEASE_TAG --upgrade
+          ${{ inputs.python-path }} -m pip install -q gable[postgres,mysql,mssql] $PRE_RELEASE_TAG --upgrade
         else
-          ${{ inputs.python-path }} -m pip install -q gable[postgres,mysql]==${{ inputs.gable-version }} $PRE_RELEASE_TAG
+          ${{ inputs.python-path }} -m pip install -q gable[postgres,mysql,mssql]==${{ inputs.gable-version }} $PRE_RELEASE_TAG
         fi
         if [ -n "$PYTHON_PATH" ]; then
           VENV_BIN_PATH=$(dirname $PYTHON_PATH)

--- a/github-actions/register-data-assets/action.yml
+++ b/github-actions/register-data-assets/action.yml
@@ -46,9 +46,9 @@ runs:
           PRE_RELEASE_TAG=""
         fi
         if [[ "${{ inputs.gable-version }}" == "latest" ]]; then
-          ${{ inputs.python-path }} -m pip install -q gable[postgres,mysql] $PRE_RELEASE_TAG --upgrade
+          ${{ inputs.python-path }} -m pip install -q gable[postgres,mysql,mssql] $PRE_RELEASE_TAG --upgrade
         else
-          ${{ inputs.python-path }} -m pip install -q gable[postgres,mysql]==${{ inputs.gable-version }} $PRE_RELEASE_TAG
+          ${{ inputs.python-path }} -m pip install -q gable[postgres,mysql,mssql]==${{ inputs.gable-version }} $PRE_RELEASE_TAG
         fi
     - name: Check out repository code
       uses: actions/checkout@v4


### PR DESCRIPTION
### Problem
When using mssql source type for checking data assets, an extra step of installing `gable[mssql]` package is needed.

### Fix
Include the package in the `Install Gable` step, as `postgres` and `mysql` are already present.

### Possible improvements
An overengineered solution would be to detect what packages are required and install only those (based on `--source-type` parameter that is provided to the binary). Not worth the effort to save a few hundred milliseconds.
